### PR TITLE
fix: idpay-app-maintainer as codeower

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/idpay-contributors @dpellicc @antonioT90 @GiovanaSolorzano @pelliccm @mpellicc
+* @pagopa/idpay-app-maintainer-team @dariopelliccioli @antonioT90 @GiovanaSolorzano @pelliccm


### PR DESCRIPTION
This PR sets @pagopa/idpay-app-maintainer-team as codeowner. 