### PR TITLE
fix: [IDP-2461] Initializing optimistic lock for UserInitiativeCounters

### DIFF
--- a/src/main/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepository.java
+++ b/src/main/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepository.java
@@ -11,4 +11,5 @@ public interface UserInitiativeCountersAtomicOpsRepository {
     Flux<UserInitiativeCounters> findByInitiativesWithBatch(String initiativeId, int batchSize);
     Mono<UserInitiativeCounters> unlockPendingTrx(String trxId);
     Mono<UserInitiativeCounters> findByPendingTrx(String trxId);
+    Mono<UserInitiativeCounters> saveIfVersionNotChanged(UserInitiativeCounters counters);
 }

--- a/src/main/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepositoryImpl.java
@@ -3,9 +3,11 @@ package it.gov.pagopa.reward.connector.repository;
 import com.mongodb.client.result.UpdateResult;
 import it.gov.pagopa.reward.dto.build.InitiativeGeneralDTO;
 import it.gov.pagopa.reward.dto.trx.TransactionDTO;
+import it.gov.pagopa.reward.exception.custom.InvalidCounterVersionException;
 import it.gov.pagopa.reward.model.counters.UserInitiativeCounters;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -69,5 +71,18 @@ public class UserInitiativeCountersAtomicOpsRepositoryImpl implements UserInitia
     public Mono<UserInitiativeCounters> findByPendingTrx(String trxId){
         Query query = Query.query(Criteria.where(PENDING_TRX_ID_FIELD).is(trxId));
         return mongoTemplate.findOne(query, UserInitiativeCounters.class);
+    }
+
+    @Override
+    public Mono<UserInitiativeCounters> saveIfVersionNotChanged(UserInitiativeCounters counters) {
+        return mongoTemplate
+                .findAndReplace(
+                        Query.query(Criteria.where(UserInitiativeCounters.Fields.id).is(counters.getId())
+                                .and(UserInitiativeCounters.Fields.version).is(counters.getVersion()-1L)),
+                        counters,
+                        FindAndReplaceOptions.options().returnNew(),
+                        UserInitiativeCounters.class,
+                        UserInitiativeCounters.class)
+                .switchIfEmpty(Mono.error(new InvalidCounterVersionException()));
     }
 }

--- a/src/main/java/it/gov/pagopa/reward/model/counters/Counters.java
+++ b/src/main/java/it/gov/pagopa/reward/model/counters/Counters.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
@@ -13,6 +14,7 @@ import java.math.RoundingMode;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder(toBuilder = true)
+@FieldNameConstants
 public class Counters {
     @Builder.Default
     private Long trxNumber = 0L;

--- a/src/main/java/it/gov/pagopa/reward/service/synchronous/op/BaseTrxSynchronousOp.java
+++ b/src/main/java/it/gov/pagopa/reward/service/synchronous/op/BaseTrxSynchronousOp.java
@@ -122,7 +122,7 @@ abstract class BaseTrxSynchronousOp {
         return ctr2rewardMono
                 .flatMap(ctr2reward -> {
                             counter.setPendingTrx(trxDTO);
-                            return userInitiativeCountersRepository.save(counter)
+                            return userInitiativeCountersRepository.saveIfVersionNotChanged(counter)
                                     .map(x -> ctr2reward.getSecond());
                         }
                 );

--- a/src/main/java/it/gov/pagopa/reward/service/synchronous/op/CancelTrxSynchronousServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/reward/service/synchronous/op/CancelTrxSynchronousServiceImpl.java
@@ -116,7 +116,7 @@ public class CancelTrxSynchronousServiceImpl extends BaseTrxSynchronousOp implem
             return Mono.error(new PendingCounterException());
         } else {
             return handleUnlockedCounterForRefundTrx("SYNC_CANCEL_TRANSACTION", trxDTO, initiativeId, counters, rewardCents)
-                    .flatMap(ctr2reward -> userInitiativeCountersRepository.save(counter)
+                    .flatMap(ctr2reward -> userInitiativeCountersRepository.saveIfVersionNotChanged(counter)
                             .map(x -> ctr2reward.getSecond())
                     );
         }

--- a/src/test/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/reward/connector/repository/UserInitiativeCountersAtomicOpsRepositoryImplTest.java
@@ -4,6 +4,7 @@ import com.mongodb.client.result.UpdateResult;
 import it.gov.pagopa.common.mongo.MongoTest;
 import it.gov.pagopa.reward.dto.build.InitiativeGeneralDTO;
 import it.gov.pagopa.reward.dto.trx.RewardTransactionDTO;
+import it.gov.pagopa.reward.exception.custom.InvalidCounterVersionException;
 import it.gov.pagopa.reward.model.counters.UserInitiativeCounters;
 import it.gov.pagopa.reward.test.fakers.RewardTransactionDTOFaker;
 import org.bson.BsonString;
@@ -12,8 +13,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static it.gov.pagopa.reward.utils.RewardConstants.REWARD_STATE_REJECTED;
@@ -118,6 +122,47 @@ class UserInitiativeCountersAtomicOpsRepositoryImplTest {
 
         assertNotNull(updateResult);
         assertNotNull(updateResult.getPendingTrx());
+
+    }
+
+    @Test
+    void saveIfVersionNotChanged(){
+        UserInitiativeCounters userInitiativeCounters = new UserInitiativeCounters(userId, InitiativeGeneralDTO.BeneficiaryTypeEnum.PF,initiativeId);
+        userInitiativeCounters.setVersion(1L);
+
+        UserInitiativeCounters userInitiativeCountersUpdate = new UserInitiativeCounters(userId, InitiativeGeneralDTO.BeneficiaryTypeEnum.PF,initiativeId);
+        userInitiativeCountersUpdate.setVersion(2L);
+        userInitiativeCountersUpdate.setTrxNumber(1L);
+        userInitiativeCountersUpdate.setTotalReward(BigDecimal.ONE);
+        userInitiativeCountersUpdate.setTotalAmount(BigDecimal.ONE);
+        userInitiativeCountersUpdate.setUpdateDate(userInitiativeCountersUpdate.getUpdateDate().truncatedTo(ChronoUnit.MILLIS));
+
+        userInitiativeCountersRepository.save(userInitiativeCounters).block();
+
+        //where
+        UserInitiativeCounters result = userInitiativeCountersRepository.saveIfVersionNotChanged(userInitiativeCountersUpdate).block();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(userInitiativeCountersUpdate, result);
+
+    }
+
+    @Test
+    void saveIfVersionNotChangedError(){
+        UserInitiativeCounters userInitiativeCounters = new UserInitiativeCounters(userId, InitiativeGeneralDTO.BeneficiaryTypeEnum.PF,initiativeId);
+        userInitiativeCounters.setVersion(2L);
+
+        UserInitiativeCounters userInitiativeCountersUpdate = new UserInitiativeCounters(userId, InitiativeGeneralDTO.BeneficiaryTypeEnum.PF,initiativeId);
+        userInitiativeCountersUpdate.setVersion(2L);
+        userInitiativeCounters.setTotalReward(BigDecimal.ONE);
+
+        userInitiativeCountersRepository.save(userInitiativeCounters).block();
+
+        //where
+        Mono<UserInitiativeCounters> serviceResult = userInitiativeCountersRepository.saveIfVersionNotChanged(userInitiativeCountersUpdate);
+        InvalidCounterVersionException result = assertThrows(InvalidCounterVersionException.class, serviceResult::block);
+
+        Assertions.assertNotNull(result);
 
     }
 }

--- a/src/test/java/it/gov/pagopa/reward/service/synchronous/op/CancelTrxSynchronousServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/reward/service/synchronous/op/CancelTrxSynchronousServiceImplTest.java
@@ -105,7 +105,7 @@ class CancelTrxSynchronousServiceImplTest{
         Mockito.when(userInitiativeCountersUpdateServiceMock.update(any(), any()))
                 .thenReturn(Mono.just(rewardTrx));
 
-        Mockito.when(userInitiativeCountersRepositoryMock.save(any())).thenReturn(Mono.just(getUserInitiativeCounters(trxCancelRequest)));
+        Mockito.when(userInitiativeCountersRepositoryMock.saveIfVersionNotChanged(any())).thenReturn(Mono.just(getUserInitiativeCounters(trxCancelRequest)));
 
         //When
         SynchronousTransactionResponseDTO result = cancelTrxSynchronousService.cancelTransaction(trxCancelRequest, INITIATIVEID).block();
@@ -118,7 +118,7 @@ class CancelTrxSynchronousServiceImplTest{
         Mockito.verify(rewardContextHolderServiceMock, Mockito.times(1)).getRewardRulesKieInitiativeIds();
         Mockito.verify(onboardedInitiativesServiceMock, Mockito.times(1)).isOnboarded(any(),any(),any());
         Mockito.verify(userInitiativeCountersRepositoryMock, Mockito.times(1)).findById(anyString());
-        Mockito.verify(userInitiativeCountersRepositoryMock, Mockito.times(1)).save(any());
+        Mockito.verify(userInitiativeCountersRepositoryMock, Mockito.times(1)).saveIfVersionNotChanged(any());
         Mockito.verify(userInitiativeCountersUpdateServiceMock, Mockito.times(1)).update(any(),any());
     }
 

--- a/src/test/java/it/gov/pagopa/reward/service/synchronous/op/CreateTrxSynchronousServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/reward/service/synchronous/op/CreateTrxSynchronousServiceImplTest.java
@@ -423,7 +423,7 @@ class CreateTrxSynchronousServiceImplTest {
     }
 
     private void mockUserInitiativeCountersRepositorySave(UserInitiativeCounters counter) {
-        Mockito.when(userInitiativeCountersRepositoryMock.save(counter)).thenReturn(Mono.just(counter));
+        Mockito.when(userInitiativeCountersRepositoryMock.saveIfVersionNotChanged(counter)).thenReturn(Mono.just(counter));
     }
 
     private void mockUserInitiativeCountersUpdateService(SynchronousTransactionRequestDTO transactionRequest, InitiativeConfig initiativeConfig, UserInitiativeCounters counter, BigDecimal reward) {


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Added optimistic lock for counters save changed

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Avoid loss-update problems

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [x] Unit
    - [x] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
